### PR TITLE
Bump version to v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ jobs:
 
       - name: "Compare Version"
         id: compare
-        uses: sharesight/compare-package-json-version-with-latest@v1.2.1
+        uses: sharesight/compare-package-json-version-with-latest@v2.0.0
         with:
           repository: ${{ github.repository }}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compare-package-json-version-with-latest",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Allows us to compare your local `package.json` version with a Github Package Registry's latest version.",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This release PR includes a slew of dependency updates, but more importantly, it includes a dependency upgrade for the runner from node 12 to node 16. Node 12 actions are now deprecated.
- https://github.com/sharesight/compare-package-json-version-with-latest/pull/186

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203916169100390